### PR TITLE
fix: 메일박스 렌더링 버그 수정

### DIFF
--- a/src/app/mail/[id]/inbox/page.tsx
+++ b/src/app/mail/[id]/inbox/page.tsx
@@ -55,7 +55,7 @@ export default async function MailInboxPage(props: {
     where: {
       memberId: user.memberId,
       trainingId: trainingId,
-      status: "ACTIVE",
+      status: { not: "FAIL" },
     },
     include: {
       mailHolders: {

--- a/src/app/mail/[id]/spam/page.tsx
+++ b/src/app/mail/[id]/spam/page.tsx
@@ -55,7 +55,7 @@ export default async function MailSpamPage(props: {
     where: {
       memberId: user.memberId,
       trainingId: trainingId,
-      status: "ACTIVE",
+      status: { not: "FAIL" },
     },
     include: {
       mailHolders: {

--- a/src/app/mail/[id]/starred/page.tsx
+++ b/src/app/mail/[id]/starred/page.tsx
@@ -55,7 +55,7 @@ export default async function MailStarredPage(props: {
     where: {
       memberId: user.memberId,
       trainingId: trainingId,
-      status: "ACTIVE",
+      status: { not: "FAIL" },
     },
     include: {
       mailHolders: {

--- a/src/app/mail/[id]/trash/page.tsx
+++ b/src/app/mail/[id]/trash/page.tsx
@@ -55,7 +55,7 @@ export default async function MailTrashPage(props: {
     where: {
       memberId: user.memberId,
       trainingId: trainingId,
-      status: "ACTIVE",
+      status: { not: "FAIL" },
     },
     include: {
       mailHolders: {


### PR DESCRIPTION
## 작업 내용

- 각 메일함 page.tsx에서 training을 불러올 때 ACTIVE만 불러오던 버그 수정
- 완료한 훈련의 메일함도 접근 가능

## 체크리스트

- [x] 주요 기능이 정상적으로 동작함
- [x] 코드에 불필요한 주석이나 디버깅 흔적이 없음
- [x] 기존 코드와 호환성에 문제가 없음
- [ ] 필요한 문서를 업데이트 함
- [x] 민감한 정보(api키 등)가 포함되어 있지 않음

## 이미지(선택)

## 추가 설명(선택)
